### PR TITLE
session item 위한 커스텀 뷰와 디자인 적용

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/widget/SessionChip.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/widget/SessionChip.kt
@@ -1,0 +1,202 @@
+package com.droidknights.app2020.widget
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.text.TextUtils
+import android.util.AttributeSet
+import android.view.Gravity
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.content.ContextCompat
+import com.droidknights.app2020.R
+
+
+class SessionChip @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : AppCompatTextView(context, attrs, defStyleAttr) {
+    var chipBackgroundColor = 0
+        set(value) {
+            field = value
+            buildView()
+        }
+
+    var chipTextColor = 0
+        set(value) {
+            field = value
+            buildView()
+        }
+
+    var cornerRadius = 0
+        set(value) {
+            field = value
+            buildView()
+        }
+    var strokeSize = 0
+        set(value) {
+            field = value
+            buildView()
+        }
+    var strokeColor = 0
+        set(value) {
+            field = value
+            buildView()
+        }
+
+init {
+        initTypedArray(attrs)
+        buildView()
+        setSingleLine()
+        ellipsize = TextUtils.TruncateAt.END
+    }
+
+    private fun initTypedArray(attrs: AttributeSet?) {
+        if (attrs == null || context == null) return
+
+        val typedArray = context.theme.obtainStyledAttributes(attrs, R.styleable.SessionChip, 0, 0)
+        //백그라운드 컬러는 글자색에서 HSL50 컬러이다.
+        chipBackgroundColor =
+            typedArray.getColor(
+                R.styleable.SessionChip_sc_textColor,
+                ContextCompat.getColor(context, R.color.color_sessionChipText)
+            ).let{
+                when(it){
+                Color.WHITE -> Color.BLACK
+                Color.BLACK -> Color.WHITE
+                else -> lighten(it, 30)
+                }
+            }
+
+
+        chipTextColor = typedArray.getColor(
+            R.styleable.SessionChip_sc_textColor,
+            ContextCompat.getColor(context, R.color.color_sessionChipText)
+        )
+        cornerRadius = typedArray.getDimensionPixelSize(
+            R.styleable.SessionChip_sc_cornerRadius,
+            resources.getDimensionPixelSize(R.dimen.SessionChip_height) / 2
+        )
+        strokeSize = typedArray.getDimensionPixelSize(R.styleable.SessionChip_sc_strokeSize, 0)
+        //stroke 컬러는 글자색과 같다.
+        strokeColor = typedArray.getColor(
+            R.styleable.SessionChip_sc_textColor,
+            ContextCompat.getColor(context, R.color.color_sessionChipText)
+        )
+
+
+        typedArray.recycle()
+
+    }
+
+    private fun buildView() {
+        createPaddings()
+        createChipText()
+        createBackground()
+    }
+
+    private fun createPaddings() {
+        gravity = Gravity.CENTER
+        val startPadding = resources.getDimensionPixelSize(R.dimen.SessionChip_horizontal_margin)
+        val topPadding = resources.getDimensionPixelSize(R.dimen.SessionChip_vertical_margin)
+        val endPadding = resources.getDimensionPixelSize(R.dimen.SessionChip_horizontal_margin)
+        val bottomPadding = resources.getDimensionPixelSize(R.dimen.SessionChip_vertical_margin)
+        setPaddingRelative(startPadding, topPadding, endPadding, bottomPadding)
+    }
+
+    private fun createChipText() {
+        setTextColor(chipTextColor)
+    }
+
+
+    private fun createBackground() {
+        val radius = cornerRadius.toFloat()
+        val radii = floatArrayOf(radius, radius, radius, radius, radius, radius, radius, radius)
+
+        background = GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            cornerRadii = radii
+            setColor(chipBackgroundColor)
+            setStroke(strokeSize, strokeColor)
+        }
+    }
+
+    //util
+
+    /**
+     * Darkens a given color.
+     *
+     * @param base base color
+     * @param amount amount between 0 and 100
+     * @return darken color
+     */
+    private fun darken(base: Int, amount: Int): Int {
+        var hsv = FloatArray(3)
+        Color.colorToHSV(base, hsv)
+
+        val hsl = hsv2hsl(hsv)
+        hsl[2] -= amount / 100f
+
+        if (hsl[2] < 0)
+            hsl[2] = 0f
+
+        hsv = hsl2hsv(hsl)
+        return Color.HSVToColor(hsv)
+    }
+
+    /**
+     * lightens a given color
+     * @param base base color
+     * @param amount amount between 0 and 100
+     * @return lightened
+     */
+    fun lighten(base: Int, amount: Int): Int {
+        var hsv = FloatArray(3)
+        Color.colorToHSV(base, hsv)
+
+        val hsl = hsv2hsl(hsv)
+        hsl[2] += amount / 100f
+
+        if (hsl[2] > 1)
+            hsl[2] = 1f
+
+        hsv = hsl2hsv(hsl)
+        return Color.HSVToColor(hsv)
+    }
+
+    /**
+     * Converts HSV (Hue, Saturation, Value) color to HSL (Hue, Saturation, Lightness)
+     * https://gist.github.com/xpansive/1337890
+     *
+     * @param hsv HSV color array
+     * @return hsl
+     */
+    private fun hsv2hsl(hsv: FloatArray): FloatArray {
+        val hue = hsv[0]
+        val sat = hsv[1]
+        val `val` = hsv[2]
+
+        val nhue = (2f - sat) * `val`
+        var nsat = sat * `val` / if (nhue < 1f) nhue else 2f - nhue
+        if (nsat > 1f)
+            nsat = 1f
+
+        return floatArrayOf(hue, nsat, nhue / 2f)
+    }
+
+    /**
+     * Reverses hsv2hsl
+     * https://gist.github.com/xpansive/1337890
+     *
+     * @param hsl HSL color array
+     * @return hsv color array
+     */
+    private fun hsl2hsv(hsl: FloatArray): FloatArray {
+        val hue = hsl[0]
+        var sat = hsl[1]
+        val light = hsl[2]
+
+        sat *= if (light < .5) light else 1 - light
+
+        return floatArrayOf(hue, 2f * sat / (light + sat), light + sat)
+    }
+
+}

--- a/androidapp/app/src/main/java/com/droidknights/app2020/widget/SessionChipGroup.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/widget/SessionChipGroup.kt
@@ -1,0 +1,201 @@
+package com.droidknights.app2020.widget
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.IntDef
+import kotlin.math.max
+import com.droidknights.app2020.R
+
+class SessionChipGroup @JvmOverloads constructor(
+    context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : ViewGroup(context, attrs, defStyleAttr) {
+    private val views = mutableListOf<List<View>>()
+    private var lineViews = mutableListOf<View>()
+    private val lineHeights = mutableListOf<Int>()
+    private val lineWidths = mutableListOf<Int>()
+    @FlowGravity
+    private var gravity: Int = START
+    private var startMargin: Float
+    private var endMargin: Float
+    private var topMargin: Float
+    private var bottomMargin: Float
+
+    companion object {
+        @IntDef(START, CENTER, END)
+        @Retention(AnnotationRetention.SOURCE)
+        annotation class FlowGravity
+
+        const val START = -1
+        const val CENTER = 0
+        const val END = 1
+    }
+
+    init {
+        val typedArray = context.obtainStyledAttributes(attrs, R.styleable.SessionChipGroup)
+        gravity = typedArray.getInt(R.styleable.SessionChipGroup_chipGravity, -1)
+        startMargin = typedArray.getDimension(R.styleable.SessionChipGroup_itemMargin, dip2px(context, 0f))
+        endMargin = typedArray.getDimension(R.styleable.SessionChipGroup_itemMargin, dip2px(context, 4f))
+        topMargin = typedArray.getDimension(R.styleable.SessionChipGroup_itemMargin, dip2px(context, 4f))
+        bottomMargin = typedArray.getDimension(R.styleable.SessionChipGroup_itemMargin, dip2px(context, 4f))
+
+        typedArray.recycle()
+    }
+
+    fun setGravity(@FlowGravity gravity: Int) {
+        this.gravity = gravity
+        requestLayout()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        val widthSpecMode = MeasureSpec.getMode(widthMeasureSpec)
+        val widthSpecSize = MeasureSpec.getSize(widthMeasureSpec)
+        val heightSpecMode = MeasureSpec.getMode(heightMeasureSpec)
+        val heightSpecSize = MeasureSpec.getSize(heightMeasureSpec)
+
+        var width = 0
+        var height = 0
+        var lineWidth = 0
+        var lineHeight = 0
+
+        for (i in 0 until childCount) {
+            val childView = getChildAt(i)
+            measureChild(childView, widthMeasureSpec, heightMeasureSpec)
+            val lp = childView.layoutParams as MarginLayoutParams
+
+            val childWidth = childView.measuredWidth + lp.leftMargin + lp.rightMargin
+            val childHeight = childView.measuredHeight + lp.topMargin + lp.bottomMargin
+
+            childView.layoutParams = lp
+
+            if (lineWidth + childWidth > widthSpecSize - paddingStart - paddingEnd) {
+                width = max(lineWidth, width)
+                lineWidth = childWidth
+                lineHeight = childHeight
+                height += lineHeight
+            } else {
+                lineWidth += childWidth
+                lineHeight = max(lineHeight, childHeight)
+            }
+
+            if (i == childCount - 1) {
+                width = max(lineWidth, width)
+                height += lineHeight
+            }
+        }
+
+        setMeasuredDimension(
+            if (widthSpecMode == MeasureSpec.EXACTLY) widthSpecSize else width + paddingStart + paddingEnd,
+            if (heightSpecMode == MeasureSpec.EXACTLY) heightSpecSize else height + paddingTop + paddingBottom
+        )
+    }
+
+    override fun onLayout(p0: Boolean, p1: Int, p2: Int, p3: Int, p4: Int) {
+        views.clear()
+        lineViews.clear()
+        lineHeights.clear()
+        lineWidths.clear()
+
+        var lineWidth = 0
+        var lineHeight = 0
+
+        for (i in 0 until childCount) {
+            val childView = getChildAt(i)
+
+            if (childView.visibility == View.GONE) {
+                continue
+            }
+            val lp = childView.layoutParams as MarginLayoutParams
+
+            val childWidth = childView.measuredWidth
+            val childHeight = childView.measuredHeight
+
+            if (childWidth + lineWidth + lp.leftMargin + lp.rightMargin > width - paddingStart - paddingEnd) {
+                views.add(lineViews)
+                lineWidths.add(lineWidth)
+                lineHeights.add(lineHeight)
+
+                lineWidth = 0
+                lineHeight = childHeight + lp.topMargin + lp.bottomMargin
+                lineViews = mutableListOf()
+            }
+
+            lineWidth += (childWidth + lp.leftMargin + lp.rightMargin)
+            lineHeight = max(lineHeight, childHeight + lp.topMargin + lp.bottomMargin)
+            lineViews.add(childView)
+        }
+
+        lineWidths.add(lineWidth)
+        lineHeights.add(lineHeight)
+        views.add(lineViews)
+
+        var top = paddingTop
+        var left: Int
+
+        for (i in 0 until views.size) {
+            val list = views[i]
+            val currentWidth = lineWidths[i]
+            left = when (gravity) {
+                START -> paddingStart
+                CENTER -> (width - currentWidth) / 2 + paddingStart
+                else -> {
+                    list.reversed()
+                    width - currentWidth - paddingStart - paddingEnd
+                }
+            }
+
+            lineHeight = lineHeights[i]
+
+            for (child in list) {
+                if (child.visibility == View.GONE) {
+                    continue
+                }
+                val lp = child.layoutParams as MarginLayoutParams
+
+                val cleft = lp.leftMargin + left
+                val cRight = cleft + child.measuredWidth
+                val cTop = lp.topMargin + top
+                val cBottom = cTop + child.measuredHeight
+                left += (child.measuredWidth + lp.leftMargin
+                        + lp.rightMargin)
+                child.layout(cleft, cTop, cRight, cBottom)
+            }
+
+            top += lineHeight
+        }
+    }
+
+    override fun generateLayoutParams(attrs: AttributeSet?): LayoutParams {
+        val lp = MarginLayoutParams(context, attrs)
+        lp.leftMargin = startMargin.toInt()
+        lp.rightMargin = endMargin.toInt()
+        lp.topMargin = topMargin.toInt()
+        lp.bottomMargin = bottomMargin.toInt()
+        return lp
+    }
+
+    override fun generateLayoutParams(p: LayoutParams?): LayoutParams {
+        val lp = MarginLayoutParams(p)
+        lp.leftMargin = startMargin.toInt()
+        lp.rightMargin = endMargin.toInt()
+        lp.topMargin = topMargin.toInt()
+        lp.bottomMargin = bottomMargin.toInt()
+        return lp
+    }
+
+    override fun generateDefaultLayoutParams(): LayoutParams {
+        val lp = MarginLayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+        lp.leftMargin = startMargin.toInt()
+        lp.rightMargin = endMargin.toInt()
+        lp.topMargin = topMargin.toInt()
+        lp.bottomMargin = bottomMargin.toInt()
+        return lp
+    }
+
+    private fun dip2px(context: Context, dpValue: Float): Float {
+        val scale = context.resources.displayMetrics.density
+        return (dpValue * scale + 0.5f)
+    }
+}

--- a/androidapp/app/src/main/res/layout/item_session.xml
+++ b/androidapp/app/src/main/res/layout/item_session.xml
@@ -21,35 +21,88 @@
 
         <TextView
             android:id="@+id/tvMemoTitle"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
             android:text="@{item.title}"
             android:textSize="16sp"
             android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/tvDate"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:text="@string/app_name"
-            />
+            tools:text="1년간 토스 앱의 '홈' 탭을 개발하며 쌓은 Learning Share" />
 
         <TextView
             android:id="@+id/tvDate"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@{item.time}"
-            app:layout_constraintTop_toBottomOf="@id/tvMemoTitle"
+            android:textColor="#00d0a8"
+            android:textStyle="bold"
             app:layout_constraintStart_toStartOf="parent"
-            tools:text="@string/app_name"
-            />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="10:45" />
 
-        <View
+        <com.droidknights.app2020.widget.SessionChipGroup
             android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_marginTop="15dp"
-            android:background="@color/colorBorder"
-            app:layout_constraintTop_toBottomOf="@id/tvDate"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            />
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@+id/tvMemoTitle"
+            app:layout_constraintTop_toBottomOf="@+id/tvMemoTitle"
+            app:layout_constraintVertical_bias="0.0">
+
+            <com.droidknights.app2020.widget.SessionChip
+                android:id="@+id/sessionChip1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="기술"
+                android:textSize="10sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tvDate"
+                app:sc_strokeSize="1dp"
+                app:sc_textColor="@color/color_sessionChipText" />
+
+            <com.droidknights.app2020.widget.SessionChip
+                android:id="@+id/sessionChip2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="경험"
+                android:textSize="10sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toEndOf="@+id/sessionChip1"
+                app:layout_constraintTop_toTopOf="@+id/sessionChip1"
+                app:sc_strokeSize="1dp"
+                app:sc_textColor="@color/color_sessionChipText_white" />
+
+            <com.droidknights.app2020.widget.SessionChip
+                android:id="@+id/sessionChip3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="심화"
+                android:textSize="10sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toEndOf="@+id/sessionChip2"
+                app:layout_constraintTop_toTopOf="@+id/sessionChip2"
+                app:sc_strokeSize="1dp"
+                app:sc_textColor="@color/color_sessionChipText_red" />
+
+            <com.droidknights.app2020.widget.SessionChip
+                android:id="@+id/sessionChip4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="중급"
+                android:textSize="10sp"
+                android:textStyle="bold"
+                app:layout_constraintStart_toEndOf="@+id/sessionChip3"
+                app:layout_constraintTop_toTopOf="@+id/sessionChip3"
+                app:sc_strokeSize="1dp"
+                app:sc_textColor="@color/color_sessionChipText_purple" />
+
+        </com.droidknights.app2020.widget.SessionChipGroup>
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/androidapp/app/src/main/res/values/attrs.xml
+++ b/androidapp/app/src/main/res/values/attrs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="SessionChipGroup">
+        <attr name="chipGravity">
+            <enum name="start" value="-1" />
+            <enum name="center" value="0" />
+            <enum name="end" value="1" />
+        </attr>
+        <attr name="itemMargin" format="dimension" />
+        <attr name="itemMarginStart" format="dimension" />
+        <attr name="itemMarginEnd" format="dimension" />
+        <attr name="itemMarginTop" format="dimension" />
+        <attr name="itemMarginBottom" format="dimension" />
+    </declare-styleable>
+
+    <declare-styleable name="SessionChip">
+        <attr name="sc_textColor" format="color" />
+        <attr name="sc_cornerRadius" format="dimension" />
+        <attr name="sc_strokeSize" format="dimension" />
+    </declare-styleable>
+</resources>

--- a/androidapp/app/src/main/res/values/colors.xml
+++ b/androidapp/app/src/main/res/values/colors.xml
@@ -3,9 +3,20 @@
     <color name="colorPrimary">#FFFFFF</color>
     <color name="colorPrimaryDark">#C7C7C7</color>
     <color name="colorAccent">#EE5050</color>
-
     <color name="colorBorder">#a0a0a0</color>
 
     <!--sponsor tab-->
     <color name="sponsor_background_color">#303033</color>
+
+    <!--custom SessionChip-->
+    <!--Default Color-->
+    <color name="color_sessionChipText">#000000</color>
+    <color name="color_sessionChipText_white">#ffffff</color>
+    <color name="color_sessionChipText_blue">#5499e8</color>
+    <color name="color_sessionChipText_purple">#5a00d0</color>
+    <color name="color_sessionChipText_orange">#ff9900</color>
+    <color name="color_sessionChipText_red">#ee5050</color>
+
+    <!--Session-->
+    <color name="color_session_date">#00d0a8</color>
 </resources>

--- a/androidapp/app/src/main/res/values/dimens.xml
+++ b/androidapp/app/src/main/res/values/dimens.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="SessionChip_height">20dp</dimen>
+    <dimen name="SessionChip_horizontal_margin">8dp</dimen>
+    <dimen name="SessionChip_vertical_margin">4dp</dimen>
+</resources>


### PR DESCRIPTION
## Issue
- close #47 

## Overview (Required)
- 세션 아이템 디자인 적용을 위한 커스텀 뷰(SessionChip, SessionChipGroup)생성
 1. SessionChip의 text컬러를 지정(sc_textColor)하면 배경화면은 자동으로 text 컬러의 30%정도 밝은 색으로설정됨
 2. SessionChipGroup은 SessionChip을 담는 컨테이너임.

- 세션 아이템 디자인 적용

## Links
- https://stackoverflow.com/questions/30870167/convert-colorprimary-to-colorprimarydark-how-much-darker
-https://material-ui.com/customization/color/#important-terms

## Screenshot
Before | After
:--: | :--:
<img src="https://i.ibb.co/6XS0pCC/2020-02-17-2-36-07.png" width="300" /> | <img src="https://i.ibb.co/Z18LMwj/2020-02-17-2-35-30.png" width="300" />
