### PR TITLE
Ui model 분리

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/data/Session.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/data/Session.kt
@@ -1,6 +1,6 @@
-package com.droidknights.app2020.ui.data
+package com.droidknights.app2020.data
 
-data class SessionData(
+data class Session(
     var id: String = "",
     var track: Int = 0,
     var title: String = "",

--- a/androidapp/app/src/main/java/com/droidknights/app2020/data/Speaker.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/data/Speaker.kt
@@ -1,6 +1,6 @@
-package com.droidknights.app2020.ui.data
+package com.droidknights.app2020.data
 
-data class SpeakerData(
+data class Speaker(
     val id: String,
     val name: String,
     val profileUrl: String,

--- a/androidapp/app/src/main/java/com/droidknights/app2020/data/Sponsor.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/data/Sponsor.kt
@@ -1,9 +1,9 @@
-package com.droidknights.app2020.ui.data
+package com.droidknights.app2020.data
 
 /**
  * Created by jiyoung on 03/02/2020
  */
-data class SponsorData(
+data class Sponsor(
     var name: String = "",
     var url: String = "",
     var image: Int?

--- a/androidapp/app/src/main/java/com/droidknights/app2020/db/SessionRepository.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/db/SessionRepository.kt
@@ -1,9 +1,9 @@
 package com.droidknights.app2020.db
 
-import com.droidknights.app2020.ui.data.SessionData
+import com.droidknights.app2020.data.Session
 import kotlinx.coroutines.flow.Flow
 
 interface SessionRepository {
-    fun get(): Flow<List<SessionData>>
-    fun getById(id: String): Flow<SessionData>
+    fun get(): Flow<List<Session>>
+    fun getById(id: String): Flow<Session>
 }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/db/SessionRepositoryImpl.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/db/SessionRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.droidknights.app2020.db
 
-import com.droidknights.app2020.ui.data.SessionData
+import com.droidknights.app2020.data.Session
 import com.google.firebase.firestore.*
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -14,18 +14,18 @@ class SessionRepositoryImpl @Inject constructor(
 ) : SessionRepository {
     private val TAG = this::class.java.simpleName
 
-    override fun get(): Flow<List<SessionData>> = flow {
+    override fun get(): Flow<List<Session>> = flow {
         val snapshot = db.collection("Session").fastGet()
         emit(snapshot.map {
-            it.toObject(SessionData::class.java)
+            it.toObject(Session::class.java)
         })
     }
 
-    override fun getById(id: String): Flow<SessionData> = flow {
+    override fun getById(id: String): Flow<Session> = flow {
         val snapshot = db.collection("Session")
             .whereEqualTo("id", id)
             .fastGet()
-        emit(snapshot.map { it.toObject(SessionData::class.java) }[0])
+        emit(snapshot.map { it.toObject(Session::class.java) }[0])
     }
 }
 

--- a/androidapp/app/src/main/java/com/droidknights/app2020/mapper/Mapper.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/mapper/Mapper.kt
@@ -1,0 +1,21 @@
+package com.droidknights.app2020.mapper
+
+import com.droidknights.app2020.data.Session
+import com.droidknights.app2020.data.Sponsor
+import com.droidknights.app2020.ui.model.UiSessionModel
+import com.droidknights.app2020.ui.model.UiSponsorModel
+
+
+fun Session.asUiModel() =
+    UiSessionModel(
+        id = id,
+        title = title,
+        time = time
+    )
+
+fun Sponsor.asUiModel() =
+    UiSponsorModel(
+        name = name,
+        url = url,
+        imageDrawableResId = image ?: 0
+    )

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/Mapper.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/Mapper.kt
@@ -15,5 +15,5 @@ fun Sponsor.asUiModel() =
     UiSponsorModel(
         name = name,
         url = url,
-        imageDrawableResId = image ?: 0
+        image = image ?: 0
     )

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/Mapper.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/Mapper.kt
@@ -1,9 +1,7 @@
-package com.droidknights.app2020.mapper
+package com.droidknights.app2020.ui.model
 
 import com.droidknights.app2020.data.Session
 import com.droidknights.app2020.data.Sponsor
-import com.droidknights.app2020.ui.model.UiSessionModel
-import com.droidknights.app2020.ui.model.UiSponsorModel
 
 
 fun Session.asUiModel() =

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/UiSessionModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/UiSessionModel.kt
@@ -1,0 +1,8 @@
+package com.droidknights.app2020.ui.model
+
+
+data class UiSessionModel(
+    val id: String,
+    val title: String,
+    val time: String
+)

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/UiSponsorModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/UiSponsorModel.kt
@@ -6,5 +6,5 @@ import androidx.annotation.DrawableRes
 data class UiSponsorModel(
     val name: String,
     val url: String,
-    @DrawableRes val imageDrawableResId: Int
+    @DrawableRes val image: Int
 )

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/UiSponsorModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/model/UiSponsorModel.kt
@@ -1,0 +1,10 @@
+package com.droidknights.app2020.ui.model
+
+import androidx.annotation.DrawableRes
+
+
+data class UiSponsorModel(
+    val name: String,
+    val url: String,
+    @DrawableRes val imageDrawableResId: Int
+)

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleAdapter.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleAdapter.kt
@@ -4,24 +4,24 @@ import androidx.recyclerview.widget.DiffUtil
 import com.droidknights.app2020.R
 import com.droidknights.app2020.common.DataBindingAdapter
 import com.droidknights.app2020.common.DataBindingViewHolder
-import com.droidknights.app2020.ui.data.SessionData
+import com.droidknights.app2020.ui.model.UiSessionModel
 
-class ScheduleAdapter : DataBindingAdapter<SessionData>(DiffCallback()) {
+class ScheduleAdapter : DataBindingAdapter<UiSessionModel>(DiffCallback()) {
     override var itemClickListener: ItemClickListener? = null
 
-    class DiffCallback : DiffUtil.ItemCallback<SessionData>() {
-        override fun areItemsTheSame(oldItem: SessionData, newItem: SessionData): Boolean {
+    class DiffCallback : DiffUtil.ItemCallback<UiSessionModel>() {
+        override fun areItemsTheSame(oldItem: UiSessionModel, newItem: UiSessionModel): Boolean {
             return oldItem.id == newItem.id
         }
 
-        override fun areContentsTheSame(oldItem: SessionData, newItem: SessionData): Boolean {
+        override fun areContentsTheSame(oldItem: UiSessionModel, newItem: UiSessionModel): Boolean {
             return oldItem.id == newItem.id
         }
     }
 
     override fun getItemViewType(position: Int) = R.layout.item_session
 
-    override fun onBindViewHolder(holder: DataBindingViewHolder<SessionData>, position: Int) {
+    override fun onBindViewHolder(holder: DataBindingViewHolder<UiSessionModel>, position: Int) {
         super.onBindViewHolder(holder, position)
         holder.itemView.setOnClickListener {
             itemClickListener?.onClickItem(getItem(position).id)

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleFragment.kt
@@ -50,7 +50,7 @@ class ScheduleFragment : BaseFragment<ScheduleViewModel, ScheduleFragmentBinding
     }
 
     private fun initObserve() {
-        viewModel.sessionListData.observe(viewLifecycleOwner, Observer {
+        viewModel.sessionList.observe(viewLifecycleOwner, Observer {
             it.let(scheduleAdapter::submitList)
             Timber.d(TAG, "getSessionListData : $it")
         })

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleViewModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleViewModel.kt
@@ -4,7 +4,8 @@ import androidx.lifecycle.*
 import com.droidknights.app2020.base.BaseViewModel
 import com.droidknights.app2020.base.DispatcherProvider
 import com.droidknights.app2020.db.SessionRepository
-import com.droidknights.app2020.ui.data.SessionData
+import com.droidknights.app2020.mapper.asUiModel
+import com.droidknights.app2020.ui.model.UiSessionModel
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject
 
@@ -14,12 +15,12 @@ import javax.inject.Inject
 class ScheduleViewModel @Inject constructor(private val dispatchers: DispatcherProvider, repo: SessionRepository) : BaseViewModel() {
 
     private val _refreshEvent = MutableLiveData<Unit>()
-    val sessionListData: LiveData<List<SessionData>> = _refreshEvent.switchMap {
+    val sessionList: LiveData<List<UiSessionModel>> = _refreshEvent.switchMap {
         liveData {
-            repo.get().collect { emit(it) }
+            repo.get().collect { emit(it.map { session -> session.asUiModel() }) }
         }
     }
-    val isRefreshing: LiveData<Boolean> = sessionListData.map { false }
+    val isRefreshing: LiveData<Boolean> = sessionList.map { false }
 
     private val _itemEvent = MutableLiveData<String>()
     val itemEvent: LiveData<String> get() = _itemEvent

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleViewModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.*
 import com.droidknights.app2020.base.BaseViewModel
 import com.droidknights.app2020.base.DispatcherProvider
 import com.droidknights.app2020.db.SessionRepository
-import com.droidknights.app2020.mapper.asUiModel
+import com.droidknights.app2020.ui.model.asUiModel
 import com.droidknights.app2020.ui.model.UiSessionModel
 import kotlinx.coroutines.flow.collect
 import javax.inject.Inject

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/detail/SessionDetailViewModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/detail/SessionDetailViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.droidknights.app2020.base.BaseViewModel
 import com.droidknights.app2020.base.DispatcherProvider
 import com.droidknights.app2020.db.SessionRepository
-import com.droidknights.app2020.ui.data.SessionData
+import com.droidknights.app2020.data.Session
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -15,7 +15,7 @@ class SessionDetailViewModel @Inject constructor(
     private val repo: SessionRepository
 ) : BaseViewModel() {
 
-    val sessionContents = MutableLiveData<SessionData>()
+    val sessionContents = MutableLiveData<Session>()
 
     fun getSessionFromFirestore(id: String) {
         viewModelScope.launch {

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorAdapter.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorAdapter.kt
@@ -3,22 +3,22 @@ package com.droidknights.app2020.ui.sponsor
 import androidx.recyclerview.widget.DiffUtil
 import com.droidknights.app2020.R
 import com.droidknights.app2020.common.DataBindingAdapter
-import com.droidknights.app2020.ui.data.SponsorData
+import com.droidknights.app2020.ui.model.UiSponsorModel
 
 /**
  * Created by jiyoung on 03/02/2020
  */
-class SponsorAdapter : DataBindingAdapter<SponsorData>(DiffCallback()) {
+class SponsorAdapter : DataBindingAdapter<UiSponsorModel>(DiffCallback()) {
     override var itemClickListener: ItemClickListener?
         get() = null
         set(value) {}
 
-    class DiffCallback : DiffUtil.ItemCallback<SponsorData>() {
-        override fun areItemsTheSame(oldItem: SponsorData, newItem: SponsorData): Boolean {
+    class DiffCallback : DiffUtil.ItemCallback<UiSponsorModel>() {
+        override fun areItemsTheSame(oldItem: UiSponsorModel, newItem: UiSponsorModel): Boolean {
             return oldItem.name == newItem.name
         }
 
-        override fun areContentsTheSame(oldItem: SponsorData, newItem: SponsorData): Boolean {
+        override fun areContentsTheSame(oldItem: UiSponsorModel, newItem: UiSponsorModel): Boolean {
             return oldItem.name == newItem.name
         }
     }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorViewModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorViewModel.kt
@@ -2,19 +2,20 @@ package com.droidknights.app2020.ui.sponsor
 
 import androidx.lifecycle.ViewModel
 import com.droidknights.app2020.R
-import com.droidknights.app2020.ui.data.SponsorData
+import com.droidknights.app2020.data.Sponsor
+import com.droidknights.app2020.mapper.asUiModel
 import javax.inject.Inject
 
 class SponsorViewModel @Inject constructor() : ViewModel() {
     val sponsorList = listOf(
-        SponsorData("toss", "https://toss.im/", R.drawable.ic_sponsor_toss),
-        SponsorData("헤이딜러", "https://dealer.heydealer.com/", R.drawable.ic_sponsor_heydealer),
-        SponsorData("LINE", "https://linepluscorp.com/", R.drawable.ic_sponsor_line),
-        SponsorData("Remember", "https://rememberapp.co.kr/home", R.drawable.ic_sponsor_remember),
-        SponsorData("강남언니", "https://about.gangnamunni.com/", R.drawable.ic_sponsor_gangnamunni),
-        SponsorData("NAVER", "https://www.navercorp.com/", R.drawable.ic_sponsor_naver),
-        SponsorData("my real trip", "https://www.myrealtrip.com/", R.drawable.ic_sponsor_myrealtrip),
-        SponsorData("카카오페이", "https://www.kakaopay.com/", R.drawable.ic_sponsor_kakaopay),
-        SponsorData("vcnc", "https://tadacareer.vcnc.co.kr/", R.drawable.ic_sponsor_vcnc)
-    )
+        Sponsor("toss", "https://toss.im/", R.drawable.ic_sponsor_toss),
+        Sponsor("헤이딜러", "https://dealer.heydealer.com/", R.drawable.ic_sponsor_heydealer),
+        Sponsor("LINE", "https://linepluscorp.com/", R.drawable.ic_sponsor_line),
+        Sponsor("Remember", "https://rememberapp.co.kr/home", R.drawable.ic_sponsor_remember),
+        Sponsor("강남언니", "https://about.gangnamunni.com/", R.drawable.ic_sponsor_gangnamunni),
+        Sponsor("NAVER", "https://www.navercorp.com/", R.drawable.ic_sponsor_naver),
+        Sponsor("my real trip", "https://www.myrealtrip.com/", R.drawable.ic_sponsor_myrealtrip),
+        Sponsor("카카오페이", "https://www.kakaopay.com/", R.drawable.ic_sponsor_kakaopay),
+        Sponsor("vcnc", "https://tadacareer.vcnc.co.kr/", R.drawable.ic_sponsor_vcnc)
+    ).map { sponsor -> sponsor.asUiModel() }
 }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorViewModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorViewModel.kt
@@ -3,7 +3,7 @@ package com.droidknights.app2020.ui.sponsor
 import androidx.lifecycle.ViewModel
 import com.droidknights.app2020.R
 import com.droidknights.app2020.data.Sponsor
-import com.droidknights.app2020.mapper.asUiModel
+import com.droidknights.app2020.ui.model.asUiModel
 import javax.inject.Inject
 
 class SponsorViewModel @Inject constructor() : ViewModel() {

--- a/androidapp/app/src/main/res/layout/item_session.xml
+++ b/androidapp/app/src/main/res/layout/item_session.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="item"
-            type="com.droidknights.app2020.ui.data.SessionData" />
+            type="com.droidknights.app2020.ui.model.UiSessionModel" />
     </data>
 
 

--- a/androidapp/app/src/main/res/layout/item_sponsor.xml
+++ b/androidapp/app/src/main/res/layout/item_sponsor.xml
@@ -34,7 +34,7 @@
             android:layout_width="0dp"
             android:layout_height="50dp"
             android:layout_marginTop="10dp"
-            app:bindImgRes="@{item.imageDrawableResId}"
+            app:bindImgRes="@{item.image}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tvName"

--- a/androidapp/app/src/main/res/layout/item_sponsor.xml
+++ b/androidapp/app/src/main/res/layout/item_sponsor.xml
@@ -7,7 +7,7 @@
 
         <variable
             name="item"
-            type="com.droidknights.app2020.ui.data.SponsorData" />
+            type="com.droidknights.app2020.ui.model.UiSponsorModel" />
     </data>
 
 
@@ -34,7 +34,7 @@
             android:layout_width="0dp"
             android:layout_height="50dp"
             android:layout_marginTop="10dp"
-            app:bindImgRes="@{item.image}"
+            app:bindImgRes="@{item.imageDrawableResId}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tvName"


### PR DESCRIPTION

## Issue
- close #53 

## Overview (Required)
- SessionData, SpeakerData, SponsorData의 불필요한 `***Data` suffix를 삭제했습니다.
- `app/data/`로 기존에 사용중인 data class들을 이동했습니다.
  - 프로젝트가 layer 기준으로 module화가 아직 되어있지 않은 상태라서 package분리만 했습니다.
- ui에 필요한 model들은 `app/ui/model`에 추가하였습니다.
- ui model로 mapping하는 extension을 추가했습니다. `asUiModel()`

### Suggestion
- `SponsorViewModel`쪽에 하드코딩되어 있는  `Sponsor`는 별도의 repository가 필요해보입니다.