### PR TITLE
Introduce Pre-packaged DB

### DIFF
--- a/androidapp/app/build.gradle
+++ b/androidapp/app/build.gradle
@@ -70,6 +70,8 @@ dependencies {
     kapt deps.dagger.compiler
     kapt deps.dagger.android_processor
 
+    implementation deps.google.gson
+
     // debugging
     implementation deps.debugging.timber
 

--- a/androidapp/app/src/main/java/com/droidknights/app2020/db/prepackage/PrePackagedDb.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/db/prepackage/PrePackagedDb.kt
@@ -1,0 +1,8 @@
+package com.droidknights.app2020.db.prepackage
+
+import com.droidknights.app2020.data.Session
+
+interface PrePackagedDb {
+    suspend fun getSessionList(): List<Session>
+    suspend fun getSessionById(id: String): Session?
+}

--- a/androidapp/app/src/main/java/com/droidknights/app2020/db/prepackage/PrePackagedDbImpl.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/db/prepackage/PrePackagedDbImpl.kt
@@ -1,0 +1,40 @@
+package com.droidknights.app2020.db.prepackage
+
+import android.content.Context
+import com.droidknights.app2020.data.Session
+import com.google.gson.Gson
+import timber.log.Timber
+
+class PrePackagedDbImpl(
+    context: Context,
+    assetsName: String
+) : PrePackagedDb {
+
+    private val sessionList: List<Session> =
+        context.readJsonStringFromAsset(assetsName)?.toSessionList().orEmpty()
+
+    private fun String.toSessionList(): List<Session> {
+        return Gson().fromJson(this, PrePackagedSessionList::class.java).session
+    }
+
+    override suspend fun getSessionList(): List<Session> {
+        return sessionList
+    }
+
+    override suspend fun getSessionById(id: String): Session? {
+        return sessionList.find { it.id == id }
+    }
+
+    private fun Context.readJsonStringFromAsset(assetsName: String): String? {
+        return try {
+            assets.open(assetsName)
+                .bufferedReader()
+                .use { it.readText() }
+        } catch (e: Exception) {
+            Timber.e(e)
+            null
+        }
+    }
+
+    private class PrePackagedSessionList(val session: List<Session>)
+}

--- a/androidapp/app/src/main/java/com/droidknights/app2020/di/AppComponent.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/di/AppComponent.kt
@@ -18,6 +18,7 @@ import javax.inject.Singleton
         ActivityBindingModule::class,
         ViewModelModule::class,
         FirestoreModule::class,
+        PrePackagedDbModule::class,
         RepositoryModule::class
     ]
 )

--- a/androidapp/app/src/main/java/com/droidknights/app2020/di/PrePackagedDbModule.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/di/PrePackagedDbModule.kt
@@ -1,0 +1,16 @@
+package com.droidknights.app2020.di
+
+import com.droidknights.app2020.MainApplication
+import com.droidknights.app2020.db.prepackage.PrePackagedDb
+import com.droidknights.app2020.db.prepackage.PrePackagedDbImpl
+import dagger.Module
+import dagger.Provides
+import javax.inject.Singleton
+
+@Module
+class PrePackagedDbModule {
+    @Singleton
+    @Provides
+    fun providePrePackagedDb(application: MainApplication): PrePackagedDb =
+        PrePackagedDbImpl(application, assetsName = "sessions.json")
+}

--- a/androidapp/dependency.gradle
+++ b/androidapp/dependency.gradle
@@ -64,6 +64,10 @@ deps.dagger = [
         android_processor: "com.google.dagger:dagger-android-processor:$versions.dagger"
 ]
 
+deps.google = [
+        gson: 'com.google.code.gson:gson:2.8.6'
+]
+
 // debugging
 deps.debugging = [
         timber      : "com.jakewharton.timber:timber:$versions.timber"


### PR DESCRIPTION
## Issue
- close #23

## Overview (Required)
- Pre-packaged DB 모듈을 추가합니다.
- Firestore snapshot이 비어있을 때, pre-packaged 데이터를 불러옵니다.
-  sessions.json은 [Gson](https://github.com/google/gson)으로 파싱합니다.

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/3405740/74842563-f975a980-536d-11ea-8b51-5c6989536f73.png" width="300" />