### PR TITLE
#63 - 세션 리스트를 정렬하는 기능 추가

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/data/Session.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/data/Session.kt
@@ -11,3 +11,15 @@ data class Session(
     var speakerDesc: String? = "",
     var speakerProfile: String? = ""
 )
+
+/**
+ * 1차: time 순서
+ * 2차: track 순서
+ */
+fun List<Session>.toSortedSessions(): List<Session> =
+    sortedWith(
+        compareBy(
+            { it.time },
+            { it.track }
+        )
+    )

--- a/androidapp/app/src/main/java/com/droidknights/app2020/data/Session.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/data/Session.kt
@@ -11,15 +11,3 @@ data class Session(
     var speakerDesc: String? = "",
     var speakerProfile: String? = ""
 )
-
-/**
- * 1차: time 순서
- * 2차: track 순서
- */
-fun List<Session>.toSortedSessions(): List<Session> =
-    sortedWith(
-        compareBy(
-            { it.time },
-            { it.track }
-        )
-    )

--- a/androidapp/app/src/main/java/com/droidknights/app2020/db/SessionRepositoryImpl.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/db/SessionRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package com.droidknights.app2020.db
 
 import com.droidknights.app2020.data.Session
-import com.droidknights.app2020.data.toSortedSessions
 import com.droidknights.app2020.db.prepackage.PrePackagedDb
 import com.google.firebase.firestore.*
 import kotlinx.coroutines.channels.awaitClose
@@ -80,3 +79,15 @@ private fun Query.toFlow(): Flow<QuerySnapshot> {
         awaitClose { listenerRegistration.remove() }
     }
 }
+
+/**
+ * 1차: time 순서
+ * 2차: track 순서
+ */
+private fun List<Session>.toSortedSessions(): List<Session> =
+    sortedWith(
+        compareBy(
+            { it.time },
+            { it.track }
+        )
+    )

--- a/androidapp/app/src/main/java/com/droidknights/app2020/db/SessionRepositoryImpl.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/db/SessionRepositoryImpl.kt
@@ -1,17 +1,19 @@
 package com.droidknights.app2020.db
 
 import com.droidknights.app2020.data.Session
+import com.droidknights.app2020.data.toSortedSessions
 import com.droidknights.app2020.db.prepackage.PrePackagedDb
 import com.google.firebase.firestore.*
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 class SessionRepositoryImpl @Inject constructor(
-    private val db : FirebaseFirestore,
+    private val db: FirebaseFirestore,
     private val prePackagedDb: PrePackagedDb
 ) : SessionRepository {
     private val TAG = this::class.java.simpleName
@@ -25,7 +27,7 @@ class SessionRepositoryImpl @Inject constructor(
                 it.toObject(Session::class.java)
             })
         }
-    }
+    }.map { it.toSortedSessions() }
 
     override fun getById(id: String): Flow<Session> = flow {
         val snapshot = db.collection("Session")


### PR DESCRIPTION
## Issue
- close #63

## Overview
- 세션을 시간순서 >> 트랙 순서로 정렬하는 기능을 추가합니다.
Repository에서 Flow map을 통해 정렬된 결과로 변환합니다.
- `time`이 `mm:dd`의 format을 띄고있어 별도로 Time formatting 없이 바로 비교합니다.
- `toSortedSessions()` 확장함수의 위치가 괜찮은지 확인 부탁드립니다.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/28249981/75775178-c03d3080-5d94-11ea-92c3-fb7347aff220.jpg" width="300" /> | <img src="https://user-images.githubusercontent.com/28249981/75775181-c0d5c700-5d94-11ea-89ca-8afa0aafcee8.jpg" width="300" />
