### PR TITLE
#74 - Navigation SafeArgs 적용

### DIFF
--- a/androidapp/app/build.gradle
+++ b/androidapp/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: "scabbard.gradle"
+apply plugin: "androidx.navigation.safeargs.kotlin"
 
 android {
     compileSdkVersion build_versions.compile_sdk

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleFragment.kt
@@ -2,7 +2,6 @@ package com.droidknights.app2020.ui.schedule
 
 import android.os.Bundle
 import android.view.View
-import androidx.core.os.bundleOf
 import androidx.lifecycle.Observer
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -55,9 +54,11 @@ class ScheduleFragment : BaseFragment<ScheduleViewModel, ScheduleFragmentBinding
             Timber.d(TAG, "getSessionListData : $it")
         })
 
-        viewModel.itemEvent.observe(viewLifecycleOwner, Observer {
-            val bundle = bundleOf("sessionId" to it)
-            binding.root.findNavController().navigate(R.id.sessionDetailFragment, bundle)
+        viewModel.itemEvent.observe(viewLifecycleOwner, Observer { event ->
+            event.getContentIfNotHandled()?.let { sessionId ->
+                val action = ScheduleFragmentDirections.actionScheduleToSessionDetail(sessionId)
+                binding.root.findNavController().navigate(action)
+            }
         })
     }
 }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleViewModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleViewModel.kt
@@ -3,6 +3,7 @@ package com.droidknights.app2020.ui.schedule
 import androidx.lifecycle.*
 import com.droidknights.app2020.base.BaseViewModel
 import com.droidknights.app2020.base.DispatcherProvider
+import com.droidknights.app2020.common.Event
 import com.droidknights.app2020.db.SessionRepository
 import com.droidknights.app2020.ui.model.asUiModel
 import com.droidknights.app2020.ui.model.UiSessionModel
@@ -22,8 +23,8 @@ class ScheduleViewModel @Inject constructor(private val dispatchers: DispatcherP
     }
     val isRefreshing: LiveData<Boolean> = sessionList.map { false }
 
-    private val _itemEvent = MutableLiveData<String>()
-    val itemEvent: LiveData<String> get() = _itemEvent
+    private val _itemEvent = MutableLiveData<Event<String>>()
+    val itemEvent: LiveData<Event<String>> get() = _itemEvent
 
     init {
         refresh()
@@ -34,6 +35,6 @@ class ScheduleViewModel @Inject constructor(private val dispatchers: DispatcherP
     }
 
     fun onClickItem(sessionId: String) {
-        _itemEvent.value = sessionId
+        _itemEvent.value = Event(sessionId)
     }
 }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/detail/SessionDetailFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/detail/SessionDetailFragment.kt
@@ -2,6 +2,7 @@ package com.droidknights.app2020.ui.schedule.detail
 
 import android.os.Bundle
 import android.view.View
+import androidx.navigation.fragment.navArgs
 import com.droidknights.app2020.R
 import com.droidknights.app2020.base.BaseFragment
 import com.droidknights.app2020.databinding.SessionDetailFragmentBinding
@@ -11,11 +12,11 @@ class SessionDetailFragment : BaseFragment<SessionDetailViewModel, SessionDetail
     SessionDetailViewModel::class
 ) {
 
+    private val args: SessionDetailFragmentArgs by navArgs()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        arguments?.getString("sessionId")?.let {
-            viewModel.getSessionFromFirestore(it)
-        }
+        viewModel.getSessionFromFirestore(args.sessionId)
 
         //TODO : Speaker 표시
     }

--- a/androidapp/app/src/main/res/navigation/nav_graph.xml
+++ b/androidapp/app/src/main/res/navigation/nav_graph.xml
@@ -6,20 +6,30 @@
     app:startDestination="@id/infoFragment">
 
     <fragment
-        android:id="@+id/scheduleFragment"
-        android:name="com.droidknights.app2020.ui.schedule.ScheduleFragment"
-        android:label="ScheduleFragment"
-        tools:layout="@layout/schedule_fragment" />
-    <fragment
         android:id="@+id/infoFragment"
         android:name="com.droidknights.app2020.ui.info.InfoFragment"
         android:label="InfoFragment"
-        tools:layout="@layout/info_fragment" />
+        tools:layout="@layout/info_fragment"/>
+
     <fragment
-        android:id="@+id/mypageFragment"
-        android:name="com.droidknights.app2020.ui.mypage.MypageFragment"
-        android:label="MypageFragment"
-        tools:layout="@layout/mypage_fragment" />
+        android:id="@+id/scheduleFragment"
+        android:name="com.droidknights.app2020.ui.schedule.ScheduleFragment"
+        android:label="ScheduleFragment"
+        tools:layout="@layout/schedule_fragment" >
+        <action
+            android:id="@+id/actionScheduleToSessionDetail"
+            app:destination="@id/sessionDetailFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim">
+            <argument
+                android:name="sessionId"
+                app:argType="string"
+                app:nullable="false" />
+        </action>
+    </fragment>
+
     <fragment
         android:id="@+id/sessionDetailFragment"
         android:name="com.droidknights.app2020.ui.schedule.detail.SessionDetailFragment"
@@ -27,6 +37,14 @@
         tools:layout="@layout/session_detail_fragment">
         <argument
             android:name="sessionId"
-            app:argType="string" />
+            app:argType="string"
+            app:nullable="false" />
     </fragment>
+
+    <fragment
+        android:id="@+id/mypageFragment"
+        android:name="com.droidknights.app2020.ui.mypage.MypageFragment"
+        android:label="MypageFragment"
+        tools:layout="@layout/mypage_fragment" />
+
 </navigation>

--- a/androidapp/build.gradle
+++ b/androidapp/build.gradle
@@ -5,6 +5,7 @@ buildscript {
         classpath gradlePlugin.android
         classpath gradlePlugin.kotlin
         classpath gradlePlugin.play_services
+        classpath gradlePlugin.navigation_safe_args
     }
 }
 

--- a/androidapp/dependency.gradle
+++ b/androidapp/dependency.gradle
@@ -86,7 +86,8 @@ ext.deps = deps
 def gradlePlugin = [
         android      : "com.android.tools.build:gradle:3.5.3",
         kotlin       : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin",
-        play_services: "com.google.gms:google-services:4.3.3"
+        play_services: "com.google.gms:google-services:4.3.3",
+        navigation_safe_args: "androidx.navigation:navigation-safe-args-gradle-plugin:$versions.navigation"
 ]
 ext.gradlePlugin = gradlePlugin
 


### PR DESCRIPTION
## Issue
- close #74 

## Overview (Required)
- 네비게이션 라이브러리의 SafeArgs를 적용합니다.
- nav_graph를 action을 사용해서 적절히 변경합니다.
- SessionViewModel의 itemEvent의 타입을 String -> Event&lt;String&gt;으로 변경합니다.
- 단일 이벤트가 아니면 뒤로가기로 복귀시 앱이 크래시나는 문제가 있습니다.
(계속 구독하고 있으면 그 시점에 NavController를 못찾기 때문)


