### PR TITLE
fragment binding 버그 수정

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/base/BaseFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/base/BaseFragment.kt
@@ -16,21 +16,22 @@ import javax.inject.Inject
 import kotlin.reflect.KClass
 
 abstract class BaseFragment<VM : ViewModel, B : ViewDataBinding>(
-    @LayoutRes val layoutResId: Int,
+    @LayoutRes private val layoutResId: Int,
     viewModelClass: KClass<VM>
 ) : DaggerFragment() {
     @Inject
     lateinit var viewModelFactory: ViewModelProvider.Factory
     protected val viewModel: VM by assistedViewModels(viewModelClass) { viewModelFactory }
 
-    protected val binding: B by lazy { DataBindingUtil.bind<B>(view!!)!! }
+    protected lateinit var binding: B
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(layoutResId, container, false)
+        binding = DataBindingUtil.inflate(inflater, layoutResId, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Issue
- close #75

## Overview (Required)

Fragment 스펙에 따른 fragment 처리가 되어있지 않음

### Fragment 스펙

- Fragment의 Fragment 자신과 View는 Create/Destroy 를 반복 함
- 원인 : binding객체를 lazy처리시 binding 객체와 binding되는 view는 고정되어 있게됨

### 수정 전

BottomNavigationView 선택에 의한 해시코드 변화

|              | binding   | binding root |
| ------------ | --------- | ------------ |
| 첫 번째 노출 | 134296661 | 87252586     |
| 두 번째 노출 | 9950843   | 35781784     |

Back key에 의한 해시코드 변화

|              | binding  | binding root |
| ------------ | -------- | ------------ |
| 첫 번째 노출 | 10926345 | 156481294    |
| 두 번째 노출 | 10926345 | 156481294    |

### lazy 수정 후

BottomNavigationView 선택에 의한 해시코드 변화

|              | binding   | binding root |
| ------------ | --------- | ------------ |
| 첫 번째 노출 | 124277516 | 134296661    |
| 두 번째 노출 | 228928003 | 57802112     |

Back key에 의한 해시코드 변화

|              | binding   | binding root |
| ------------ | --------- | ------------ |
| 첫 번째 노출 | 134296661 | 87252586     |
| 두 번째 노출 | 80312922  | 145536139    |