### PR TITLE
Lint, Fragment대신 FragmentContainerView 처리, 불필요 로컬 변수 처리 개선

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/MainActivity.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/MainActivity.kt
@@ -2,8 +2,9 @@ package com.droidknights.app2020.ui
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.NavigationUI
+import androidx.navigation.ui.setupWithNavController
 import com.droidknights.app2020.R
 import com.droidknights.app2020.databinding.MainActivityBinding
 import dagger.hilt.android.AndroidEntryPoint
@@ -12,18 +13,15 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private val TAG = this::class.java.simpleName
 
-    private var navHostFragment: NavHostFragment? = null
-
-    private val binding by lazy { MainActivityBinding.inflate(layoutInflater) }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(binding.root)
 
-        navHostFragment =
-            supportFragmentManager.findFragmentById(R.id.navHostFragment) as NavHostFragment?
-        navHostFragment?.let {
-            NavigationUI.setupWithNavController(binding.bottomNav, it.navController)
-        }
+        val binding =
+            DataBindingUtil.setContentView<MainActivityBinding>(this, R.layout.main_activity)
+
+        val navHostFragment = supportFragmentManager.findFragmentById(R.id.navHostFragment)
+                as NavHostFragment
+        val navController = navHostFragment.navController
+        binding.bottomNav.setupWithNavController(navController)
     }
 }

--- a/androidapp/app/src/main/res/layout/main_activity.xml
+++ b/androidapp/app/src/main/res/layout/main_activity.xml
@@ -8,7 +8,7 @@
         android:layout_height="match_parent"
         tools:context=".ui.MainActivity">
 
-        <fragment
+        <androidx.fragment.app.FragmentContainerView
             android:id="@+id/navHostFragment"
             android:name="androidx.navigation.fragment.NavHostFragment"
             android:layout_width="0dp"


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- Lint, 대응 
   - `Use FragmentContainerView instead of the <fragment> tag`
- navController 관련 처리 개선
- 불필요 로컬 변수 선언 제거 

## Links
- https://developer.android.com/reference/androidx/fragment/app/FragmentContainerView.html
