### PR TITLE
BaseFragment의 DataBinding/ViewModel Lazy 처리

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/base/BaseFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/base/BaseFragment.kt
@@ -1,9 +1,7 @@
 package com.droidknights.app2020.base
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
@@ -15,25 +13,17 @@ import com.droidknights.app2020.BR
 abstract class BaseFragment<VM : ViewModel, B : ViewDataBinding>(
     @LayoutRes private val layoutResId: Int,
     private val viewModelClass: Class<VM>
-) : Fragment() {
+) : Fragment(layoutResId) {
 
-    protected lateinit var viewModel: VM
-
-    protected lateinit var binding: B
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        viewModel = ViewModelProvider(this).get(viewModelClass)
+    protected val viewModel: VM by lazy {
+        ViewModelProvider(this).get(viewModelClass)
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = DataBindingUtil.inflate(inflater, layoutResId, container, false)
-        return binding.root
+    protected val binding: B by lazy {
+        bind(requireView()) as B
     }
+
+    private fun <T : ViewDataBinding> bind(view: View): T = DataBindingUtil.bind(view)!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)


### PR DESCRIPTION
## Issue
- close N/A

## Overview (Required)
- BaseFragment 내부의 DataBinding/ViewModel은 Fragment 생성시 바로 생성 됨
- Lazy처리로 처리로 필요시에 생성으로 수정