### PR TITLE
Resolve issue #110

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/base/BaseFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/base/BaseFragment.kt
@@ -19,14 +19,15 @@ abstract class BaseFragment<VM : ViewModel, B : ViewDataBinding>(
         ViewModelProvider(this).get(viewModelClass)
     }
 
-    protected val binding: B by lazy {
-        bind(requireView()) as B
-    }
+    private lateinit var _binding: B
+
+    protected val binding: B get() = _binding
 
     private fun <T : ViewDataBinding> bind(view: View): T = DataBindingUtil.bind(view)!!
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        _binding = bind(view)
         with(binding) {
             setVariable(BR.vm, viewModel)
             lifecycleOwner = viewLifecycleOwner


### PR DESCRIPTION
## Issue
- close #110

## Overview (Required)
- Navigation Component사용시 특정 화면으로 이동했다가 백버을 클릭할 경우 onViewCreated가 다시 호출되는 것을 확인했습니다.
- 기존 BaseFragment의 binding객체는 해당 프래그먼트의 생에 단 한번 생성되기 때문에 onViewCreated가 다시 호출되어 변경된 root View를  트랙킹하지 못하여 발생되는 이슈였습니다.
- 최대한 기존 포맷을 지키고자 private 필드를 만들어 onViewCreated 때마다 초기화되게 수정하였습니다.