### PR TITLE
DataBindingAdapter 에서 아이템 클릭 처리 코드 개선

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/common/DataBindingAdapter.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/common/DataBindingAdapter.kt
@@ -4,22 +4,17 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
+import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 
-abstract class DataBindingAdapter<T>(diffCallback: DiffUtil.ItemCallback<T>) :
+abstract class DataBindingAdapter<T>(diffCallback: DiffUtil.ItemCallback<T>, private val viewModel: ViewModel) :
     ListAdapter<T, DataBindingViewHolder<T>>(diffCallback) {
-
-    interface ItemClickListener {
-        fun onClickItem(sessionId: String)
-    }
-
-    abstract var itemClickListener : ItemClickListener?
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DataBindingViewHolder<T> {
         val layoutInflater = LayoutInflater.from(parent.context)
         val binding = DataBindingUtil.inflate<ViewDataBinding>(layoutInflater, viewType, parent, false)
-        return DataBindingViewHolder(binding)
+        return DataBindingViewHolder(binding, viewModel)
     }
 
     override fun onBindViewHolder(holder: DataBindingViewHolder<T>, position: Int) {

--- a/androidapp/app/src/main/java/com/droidknights/app2020/common/DataBindingViewHolder.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/common/DataBindingViewHolder.kt
@@ -2,12 +2,14 @@ package com.droidknights.app2020.common
 
 import androidx.databinding.ViewDataBinding
 import androidx.databinding.library.baseAdapters.BR
+import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.RecyclerView
 
-class DataBindingViewHolder<T>(private val binding: ViewDataBinding) : RecyclerView.ViewHolder(binding.root) {
+class DataBindingViewHolder<T>(val binding: ViewDataBinding, private val viewModel: ViewModel) : RecyclerView.ViewHolder(binding.root) {
 
     fun bind(item: T) {
         binding.setVariable(BR.item, item)
+        binding.setVariable(BR.viewModel, viewModel)
         binding.executePendingBindings()
     }
 }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleAdapter.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleAdapter.kt
@@ -3,11 +3,9 @@ package com.droidknights.app2020.ui.schedule
 import androidx.recyclerview.widget.DiffUtil
 import com.droidknights.app2020.R
 import com.droidknights.app2020.common.DataBindingAdapter
-import com.droidknights.app2020.common.DataBindingViewHolder
 import com.droidknights.app2020.ui.model.UiSessionModel
 
-class ScheduleAdapter : DataBindingAdapter<UiSessionModel>(DiffCallback()) {
-    override var itemClickListener: ItemClickListener? = null
+class ScheduleAdapter(viewModel: ScheduleViewModel) : DataBindingAdapter<UiSessionModel>(DiffCallback(), viewModel) {
 
     class DiffCallback : DiffUtil.ItemCallback<UiSessionModel>() {
         override fun areItemsTheSame(oldItem: UiSessionModel, newItem: UiSessionModel): Boolean {
@@ -21,10 +19,4 @@ class ScheduleAdapter : DataBindingAdapter<UiSessionModel>(DiffCallback()) {
 
     override fun getItemViewType(position: Int) = R.layout.item_session
 
-    override fun onBindViewHolder(holder: DataBindingViewHolder<UiSessionModel>, position: Int) {
-        super.onBindViewHolder(holder, position)
-        holder.itemView.setOnClickListener {
-            itemClickListener?.onClickItem(getItem(position).id)
-        }
-    }
 }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleFragment.kt
@@ -11,7 +11,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.droidknights.app2020.BR
 import com.droidknights.app2020.R
 import com.droidknights.app2020.base.BaseFragment
-import com.droidknights.app2020.common.DataBindingAdapter
 import com.droidknights.app2020.databinding.ScheduleFragmentBinding
 import com.droidknights.app2020.util.eventObserve
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,7 +26,7 @@ class ScheduleFragment : BaseFragment<ScheduleEmptyViewModel, ScheduleFragmentBi
 ) {
     private val TAG = this@ScheduleFragment::class.java.simpleName
 
-    private val scheduleAdapter = ScheduleAdapter()
+    private lateinit var scheduleAdapter : ScheduleAdapter
 
     val scheduleViewModel by activityViewModels<ScheduleViewModel>()
 
@@ -47,14 +46,7 @@ class ScheduleFragment : BaseFragment<ScheduleEmptyViewModel, ScheduleFragmentBi
     }
 
     private fun initView() {
-        scheduleAdapter.apply {
-            itemClickListener = object : DataBindingAdapter.ItemClickListener {
-                override fun onClickItem(sessionId: String) {
-                    scheduleViewModel.onClickItem(sessionId)
-                }
-            }
-        }
-
+        scheduleAdapter = ScheduleAdapter(scheduleViewModel)
         binding.rvSchedule.apply {
             layoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
             adapter = scheduleAdapter

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/filter/ScheduleFilterFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/filter/ScheduleFilterFragment.kt
@@ -1,6 +1,7 @@
 package com.droidknights.app2020.ui.schedule.filter
 
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorAdapter.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorAdapter.kt
@@ -5,12 +5,12 @@ import com.droidknights.app2020.R
 import com.droidknights.app2020.common.DataBindingAdapter
 import com.droidknights.app2020.common.DataBindingViewHolder
 import com.droidknights.app2020.ui.model.UiSponsorModel
+import com.droidknights.app2020.ui.schedule.ScheduleViewModel
 
 /**
  * Created by jiyoung on 03/02/2020
  */
-class SponsorAdapter : DataBindingAdapter<UiSponsorModel>(DiffCallback()) {
-    override var itemClickListener: ItemClickListener? = null
+class SponsorAdapter(viewModel: SponsorViewModel) : DataBindingAdapter<UiSponsorModel>(DiffCallback(), viewModel) {
 
     class DiffCallback : DiffUtil.ItemCallback<UiSponsorModel>() {
         override fun areItemsTheSame(oldItem: UiSponsorModel, newItem: UiSponsorModel): Boolean {
@@ -24,11 +24,4 @@ class SponsorAdapter : DataBindingAdapter<UiSponsorModel>(DiffCallback()) {
 
     override fun getItemViewType(position: Int) = R.layout.item_sponsor
 
-    override fun onBindViewHolder(holder: DataBindingViewHolder<UiSponsorModel>, position: Int) {
-        super.onBindViewHolder(holder, position)
-        holder.itemView.setOnClickListener {
-            val url = getItem(position).url
-            itemClickListener?.onClickItem(url)
-        }
-    }
 }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorFragment.kt
@@ -8,6 +8,7 @@ import com.droidknights.app2020.R
 import com.droidknights.app2020.base.BaseFragment
 import com.droidknights.app2020.common.DataBindingAdapter
 import com.droidknights.app2020.databinding.SponsorFragmentBinding
+import com.droidknights.app2020.util.eventObserve
 import dagger.hilt.android.AndroidEntryPoint
 
 /**
@@ -21,26 +22,29 @@ class SponsorFragment : BaseFragment<SponsorViewModel, SponsorFragmentBinding>(
     //TODO : 행사와 관련된 정보
     //TODO : 코엑스 위치 지도
     //TODO : 세션장 지도 이미지
-    private val sponsorAdapter = SponsorAdapter()
+    private lateinit var sponsorAdapter : SponsorAdapter
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         initView()
+        initObserve()
     }
 
     private fun initView() = with(binding) {
+        sponsorAdapter = SponsorAdapter(viewModel)
         sponsorAdapter.run {
             submitList(viewModel.sponsorList)
-            itemClickListener = object : DataBindingAdapter.ItemClickListener {
-                override fun onClickItem(sessionId: String) {
-                    sessionId.let(::openWebUrl)
-                }
-            }
         }
 
         binding.rvSponsor.run {
             adapter = sponsorAdapter
+        }
+    }
+
+    private fun initObserve() {
+        viewModel.onClickSponsorEvent.eventObserve(viewLifecycleOwner) { url ->
+            openWebUrl(url)
         }
     }
 

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorViewModel.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/sponsor/SponsorViewModel.kt
@@ -1,8 +1,11 @@
 package com.droidknights.app2020.ui.sponsor
 
 import androidx.hilt.lifecycle.ViewModelInject
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.droidknights.app2020.R
+import com.droidknights.app2020.common.Event
 import com.droidknights.app2020.data.Sponsor
 import com.droidknights.app2020.ui.model.asUiModel
 
@@ -17,4 +20,11 @@ class SponsorViewModel @ViewModelInject constructor() : ViewModel() {
         Sponsor("카카오페이", "https://www.kakaopay.com/", R.drawable.ic_sponsor_kakaopay),
         Sponsor("vcnc", "https://tadacareer.vcnc.co.kr/", R.drawable.ic_sponsor_vcnc)
     ).map { sponsor -> sponsor.asUiModel() }
+
+    private val _onClickSponsorEvent = MutableLiveData<Event<String>>()
+    val onClickSponsorEvent : LiveData<Event<String>> get() = _onClickSponsorEvent
+
+    fun onClickSponsor (link: String) {
+        _onClickSponsorEvent.value = Event(link)
+    }
 }

--- a/androidapp/app/src/main/res/layout/item_session.xml
+++ b/androidapp/app/src/main/res/layout/item_session.xml
@@ -8,6 +8,9 @@
         <variable
             name="item"
             type="com.droidknights.app2020.ui.model.UiSessionModel" />
+        <variable
+            name="viewModel"
+            type="com.droidknights.app2020.ui.schedule.ScheduleViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -18,6 +21,7 @@
         android:paddingEnd="15dp"
         android:paddingBottom="5dp"
         android:background="?attr/selectableItemBackground"
+        android:onClick="@{() -> viewModel.onClickItem(item.id)}"
         tools:background="@android:color/white">
 
         <TextView

--- a/androidapp/app/src/main/res/layout/item_sponsor.xml
+++ b/androidapp/app/src/main/res/layout/item_sponsor.xml
@@ -8,6 +8,9 @@
         <variable
             name="item"
             type="com.droidknights.app2020.ui.model.UiSponsorModel" />
+        <variable
+            name="viewModel"
+            type="com.droidknights.app2020.ui.sponsor.SponsorViewModel" />
     </data>
 
 
@@ -15,7 +18,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="15dp"
-        tools:background="@color/sponsor_background_color">
+        tools:background="@color/sponsor_background_color"
+        android:onClick="@{()-> viewModel.onClickSponsor(item.url)}">
 
         <TextView
             android:id="@+id/tvName"


### PR DESCRIPTION
## Issue
- close X

## Overview (Required)
- 리스트 화면에서 아이템 클릭 처리를 listener를 통해서가 아닌, 데이터바인딩을 활용할 수 있는 방법으로 코드를 변경해보았습니다.
- DataBindingAdapter에서 ItemClickListener 인터페이스 제거
- DataBindingViewHolder 생성자에 ViewModel 주입
- 아이템뷰 xml에 variable로 viewModel 추가
- 아이템 onClick 에 viewModel과 연결하여 클릭 처리

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
