### PR TITLE
FCM 푸시 구현

### DIFF
--- a/androidapp/app/build.gradle
+++ b/androidapp/app/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     // firebase
     implementation deps.firebase.analytics
     implementation deps.firebase.firestore
+    implementation deps.firebase.messaging
 
     // Dagger
     implementation deps.hilt.android

--- a/androidapp/app/src/main/AndroidManifest.xml
+++ b/androidapp/app/src/main/AndroidManifest.xml
@@ -10,6 +10,25 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_alarm" />
+        <!-- Set color used with incoming notification messages. This is used when no color is set for the incoming
+             notification message. See README(https://goo.gl/6BKBk7) for more. -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/color_session_date" />
+
+        <service
+            android:name=".push.MyFirebaseMessagingService"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+                <action android:name="com.google.firebase.INSTANCE_ID_EVENT"/>
+            </intent-filter>
+        </service>
+
         <activity android:name=".ui.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/androidapp/app/src/main/java/com/droidknights/app2020/push/MyFirebaseMessagingService.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/push/MyFirebaseMessagingService.kt
@@ -1,0 +1,74 @@
+package com.droidknights.app2020.push
+
+import android.app.*
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.droidknights.app2020.R
+import com.droidknights.app2020.ui.MainActivity
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import timber.log.Timber
+
+class MyFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onNewToken(s: String) {
+        super.onNewToken(s)
+        Timber.d("FCM_NEW_TOKEN $s")
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        super.onMessageReceived(remoteMessage)
+        val title = remoteMessage.data["title"]
+        val message = remoteMessage.data["message"]
+        val data = remoteMessage.data["data"]
+        val intent = Intent(this, MainActivity::class.java)
+        intent.putExtra("data", data)
+
+        val pendingIntent =
+            PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channelId = "채널"
+            val channelName = "영상 업로드 알림"
+            val channelMessage = NotificationChannel(
+                channelId, channelName,
+                NotificationManager.IMPORTANCE_DEFAULT
+            ).apply {
+                description = "영상 콘텐츠 업로드 안내 및 라이브 시작 알림."
+                enableLights(true)
+                enableVibration(true)
+                setShowBadge(false)
+                vibrationPattern = longArrayOf(1000, 1000)
+            }
+            notificationManager.createNotificationChannel(channelMessage)
+
+            val notificationBuilder =
+                NotificationCompat.Builder(this, channelId)
+                    .setSmallIcon(R.drawable.ic_alarm)
+                    .setContentTitle(title)
+                    .setContentText(message)
+                    .setChannelId(channelId)
+                    .setAutoCancel(true)
+                    .setContentIntent(pendingIntent)
+                    .setDefaults(Notification.DEFAULT_SOUND or Notification.DEFAULT_VIBRATE)
+
+            notificationManager.notify(9999, notificationBuilder.build())
+        } else {
+            val notificationBuilder =
+                NotificationCompat.Builder(this, "")
+                    .setSmallIcon(R.drawable.ic_alarm)
+                    .setContentTitle(title)
+                    .setContentText(message)
+                    .setAutoCancel(true)
+                    .setContentIntent(pendingIntent)
+                    .setDefaults(Notification.DEFAULT_SOUND or Notification.DEFAULT_VIBRATE)
+
+            notificationManager.notify(9999, notificationBuilder.build())
+        }
+    }
+}

--- a/androidapp/app/src/main/java/com/droidknights/app2020/push/MyFirebaseMessagingService.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/push/MyFirebaseMessagingService.kt
@@ -32,8 +32,8 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
+        val channelId = "채널"
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val channelId = "채널"
             val channelName = "영상 업로드 알림"
             val channelMessage = NotificationChannel(
                 channelId, channelName,
@@ -47,28 +47,17 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
             }
             notificationManager.createNotificationChannel(channelMessage)
 
-            val notificationBuilder =
-                NotificationCompat.Builder(this, channelId)
-                    .setSmallIcon(R.drawable.ic_alarm)
-                    .setContentTitle(title)
-                    .setContentText(message)
-                    .setChannelId(channelId)
-                    .setAutoCancel(true)
-                    .setContentIntent(pendingIntent)
-                    .setDefaults(Notification.DEFAULT_SOUND or Notification.DEFAULT_VIBRATE)
-
-            notificationManager.notify(9999, notificationBuilder.build())
-        } else {
-            val notificationBuilder =
-                NotificationCompat.Builder(this, "")
-                    .setSmallIcon(R.drawable.ic_alarm)
-                    .setContentTitle(title)
-                    .setContentText(message)
-                    .setAutoCancel(true)
-                    .setContentIntent(pendingIntent)
-                    .setDefaults(Notification.DEFAULT_SOUND or Notification.DEFAULT_VIBRATE)
-
-            notificationManager.notify(9999, notificationBuilder.build())
         }
+        val notificationBuilder =
+            NotificationCompat.Builder(this, channelId)
+                .setSmallIcon(R.drawable.ic_alarm)
+                .setContentTitle(title)
+                .setContentText(message)
+                .setChannelId(channelId)
+                .setAutoCancel(true)
+                .setContentIntent(pendingIntent)
+                .setDefaults(Notification.DEFAULT_SOUND or Notification.DEFAULT_VIBRATE)
+
+        notificationManager.notify(9999, notificationBuilder.build())
     }
 }

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/MainActivity.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.navigation.ui.setupWithNavController
 import com.droidknights.app2020.R
 import com.droidknights.app2020.databinding.MainActivityBinding
 import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
@@ -15,6 +16,11 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (intent != null) { //푸시알림을 선택해서 실행한것이 아닌경우 예외처리
+            val notificationData = intent.getStringExtra("data")
+            if (notificationData != null) Timber.d("FCM_TEST_DATA $notificationData")
+        }
 
         val binding =
             DataBindingUtil.setContentView<MainActivityBinding>(this, R.layout.main_activity)

--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/MainActivity.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/MainActivity.kt
@@ -17,9 +17,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        if (intent != null) { //푸시알림을 선택해서 실행한것이 아닌경우 예외처리
-            val notificationData = intent.getStringExtra("data")
-            if (notificationData != null) Timber.d("FCM_TEST_DATA $notificationData")
+        intent?.getStringExtra("data")?.let{
+            // TODO : 푸시 알림으로 진입 시 처리
+            Timber.d("FCM_TEST_DATA $it")
         }
 
         val binding =

--- a/androidapp/dependency.gradle
+++ b/androidapp/dependency.gradle
@@ -9,6 +9,7 @@ def versions = [:]
 versions.kotlin = "1.4.0"
 versions.firebase = "17.2.2"
 versions.firestore = "21.3.1"
+versions.messaging = "20.2.4"
 versions.lifecycle = "2.2.0"
 versions.coroutine = "1.3.9"
 versions.navigation = "2.3.0"
@@ -56,7 +57,8 @@ deps.kotlin = kotlin
 deps.firebase = [
         core     : "com.google.firebase:firebase-core:$versions.firebase",
         analytics: "com.google.firebase:firebase-analytics:$versions.firebase",
-        firestore: "com.google.firebase:firebase-firestore:$versions.firestore"
+        firestore: "com.google.firebase:firebase-firestore:$versions.firestore",
+        messaging: "com.google.firebase:firebase-messaging:$versions.messaging"
 ]
 
 // Hilt


### PR DESCRIPTION
## Issue
- close #125 

## Overview (Required)
- FirebaseMessagingService에서 디바이스 토큰을 생성받고, 메시지 수신부를 구현.
- Notification에 title, message 를 표시한다.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="https://user-images.githubusercontent.com/7722921/91650340-4a065600-eab9-11ea-8772-331f293183ab.png" width="300" />
