### PR TITLE
#128, Kotlin 1.4와 AndroidX lifecycle 마이그레이션

### DIFF
--- a/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleFragment.kt
+++ b/androidapp/app/src/main/java/com/droidknights/app2020/ui/schedule/ScheduleFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
## Issue
- close #128

## Overview (Required)
- Kotlin 1.4와 AndroidX lifecycle 마이그레이션
- Android Studio 4.0.1에서 체크를 해봐야합니다

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1534926/91652885-2ac9f180-ead6-11ea-823f-c4a4fc0bd7e4.png" width="300" /> | <img src="" width="300" />
